### PR TITLE
Return actual date on events

### DIFF
--- a/cmd/calendar-bot/calendar-bot.go
+++ b/cmd/calendar-bot/calendar-bot.go
@@ -93,7 +93,6 @@ func main() {
 	}
 	timezone := time.Local
 	s := gocron.NewScheduler(timezone)
-
 	infoLog.Printf("Scheduling notifications for %s", notifyTime.Format("15:04"))
 	s.Every(1).Day().At(notifyTime).Do(func() {
 		infoLog.Println("Start Notification")
@@ -110,6 +109,7 @@ func main() {
 			return
 		}
 		infoLog.Printf("Sending notification with %d events\n", len(todayEvents))
+
 		tmplMsg, err := message.NewTemplatedMessage(*htmlTmplPath, *txtTmplPath, todayEvents, timezone)
 		if err != nil {
 			errLog.Println(err)

--- a/pkg/calendar/calendar.go
+++ b/pkg/calendar/calendar.go
@@ -1,6 +1,7 @@
 package calendar
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"sort"
@@ -17,8 +18,18 @@ type Calendar struct {
 	*log.Logger
 }
 
+type EventData struct {
+	UID         string
+	Start       time.Time
+	End         time.Time
+	Summary     string
+	Location    string
+	Description string
+}
+
 func NewCalendar(url string, l *log.Logger) (Calendar, error) {
 	calendar := Calendar{url: url, tz: time.Local}
+
 	resp, err := http.Get(url)
 	if err != nil {
 		return calendar, err
@@ -36,18 +47,18 @@ func NewCalendar(url string, l *log.Logger) (Calendar, error) {
 	return calendar, nil
 }
 
-func (cal Calendar) GetEventsOn(date time.Time) ([]ical.Event, error) {
+func (cal Calendar) GetEventsOn(date time.Time) ([]EventData, error) {
 	events := make([]ical.Event, 0)
 	todayStart := GetDateWithoutTime(date)
 	todayEnd := todayStart.Add(24 * time.Hour)
 	for _, event := range cal.Events() {
 		start, err := event.DateTimeStart(cal.tz)
 		if err != nil {
-			return []ical.Event{}, err
+			return []EventData{}, err
 		}
 		end, err := event.DateTimeEnd(cal.tz)
 		if err != nil {
-			return []ical.Event{}, err
+			return []EventData{}, err
 		}
 		// regular event
 		if (start.After(todayStart) || start.Local() == todayStart.Local()) && start.Before(todayEnd) || (start.Before(todayStart) && end.After(todayEnd)) {
@@ -85,9 +96,76 @@ func (cal Calendar) GetEventsOn(date time.Time) ([]ical.Event, error) {
 			uids[uid] = struct{}{}
 		}
 	}
-	return dedupedEvents, nil
+
+	// Convert ical.Events to EventData
+	eventDatas := make([]EventData, 0)
+	for _, event := range dedupedEvents {
+		eventData, err := cal.ConvertToEventData(event, date)
+		if err != nil {
+			return nil, err
+		}
+		eventDatas = append(eventDatas, eventData)
+	}
+
+	return eventDatas, nil
 }
 
 func GetDateWithoutTime(date time.Time) time.Time {
 	return time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.Local)
+}
+func (cal Calendar) ConvertToEventData(icalEvent ical.Event, d time.Time) (EventData, error) {
+	eventData := EventData{}
+
+	// Handle UID
+	uidProp := icalEvent.Props.Get(ical.PropUID)
+	if uidProp != nil {
+		eventData.UID = uidProp.Value
+	} else {
+		return eventData, fmt.Errorf("UID is missing for event %s", icalEvent.Name)
+	}
+
+	// Handle DTSTART
+	startProp := icalEvent.Props.Get(ical.PropDateTimeStart)
+	if startProp == nil {
+		return eventData, fmt.Errorf("DTSTART is missing for event %s", icalEvent.Name)
+	}
+	eventStart, err := startProp.DateTime(cal.tz)
+	if err != nil {
+		return eventData, err
+	}
+	eventData.Start = time.Date(d.Year(), d.Month(), d.Day(), eventStart.Hour(), eventStart.Minute(), 0, 0, d.Location())
+
+	// Handle DTEND
+	endProp := icalEvent.Props.Get(ical.PropDateTimeEnd)
+	if endProp != nil {
+		eventEnd, err := endProp.DateTime(cal.tz)
+		if err != nil {
+			return eventData, err
+		}
+		// Calculate the difference in days and adjust eventData.End
+		daysDiff := int(eventEnd.Sub(eventStart).Hours() / 24)
+		eventData.End = time.Date(d.Year(), d.Month(), d.Day()+daysDiff, eventEnd.Hour(), eventEnd.Minute(), 0, 0, d.Location())
+	}
+
+	// Handle SUMMARY
+	summaryProp := icalEvent.Props.Get(ical.PropSummary)
+	if summaryProp != nil {
+		eventData.Summary = summaryProp.Value
+	}
+
+	// Handle LOCATION
+	locationProp := icalEvent.Props.Get(ical.PropLocation)
+	if locationProp != nil {
+		eventData.Location = locationProp.Value
+	}
+
+	// Handle DESCRIPTION
+	descriptionProp := icalEvent.Props.Get(ical.PropDescription)
+	if descriptionProp != nil {
+		eventData.Description = descriptionProp.Value
+	} else {
+		eventData.Description = ""
+	}
+
+	return eventData, nil
 }

--- a/pkg/calendar/calendar_test.go
+++ b/pkg/calendar/calendar_test.go
@@ -14,27 +14,12 @@ const (
 	xHainDump_1 = "testData.txt"
 )
 
-func NewWantedCalendarEventWithUIDAndSummary(uid string, summary string) ical.Event {
-	return ical.Event{
-		Component: &ical.Component{
-			Name: ical.CompEvent,
-			Props: ical.Props{
-				ical.PropSummary: []ical.Prop{
-					{
-						Name:   ical.PropSummary,
-						Params: make(ical.Params),
-						Value:  summary,
-					},
-				},
-				ical.PropUID: []ical.Prop{
-					{
-						Name:   ical.PropUID,
-						Params: make(ical.Params),
-						Value:  uid,
-					},
-				},
-			},
-		},
+func NewWantedCalendarEvent(uid string, summary string, start time.Time, end time.Time) EventData {
+	return EventData{
+		UID:     uid,
+		Summary: summary,
+		Start:   start,
+		End:     end,
 	}
 }
 
@@ -51,7 +36,7 @@ func TestCalendar_GetEventsOn(t *testing.T) {
 		name         string
 		testDataFile io.ReadCloser
 		args         args
-		want         []ical.Event
+		want         []EventData
 		wantErr      bool
 	}{
 		{
@@ -61,8 +46,13 @@ func TestCalendar_GetEventsOn(t *testing.T) {
 				date: time.Date(2023, 2, 23, 0, 0, 0, 0, time.Local),
 			},
 			wantErr: false,
-			want: []ical.Event{
-				NewWantedCalendarEventWithUIDAndSummary("dae1e4eb-7213-4620-bc9f-1bdb8a023af9", "Workshop - Learn PCB design with KiCad"),
+			want: []EventData{
+				NewWantedCalendarEvent(
+					"dae1e4eb-7213-4620-bc9f-1bdb8a023af9",
+					"Workshop - Learn PCB design with KiCad",
+					time.Date(2023, 2, 23, 18, 30, 0, 0, time.Local),
+					time.Date(2023, 2, 23, 20, 30, 0, 0, time.Local),
+				),
 			},
 		},
 		{
@@ -72,8 +62,13 @@ func TestCalendar_GetEventsOn(t *testing.T) {
 				date: time.Date(2023, 3, 2, 0, 0, 0, 0, time.Local),
 			},
 			wantErr: false,
-			want: []ical.Event{
-				NewWantedCalendarEventWithUIDAndSummary("66adcfc4-6827-45a2-a5b4-655923d5dd62", "How to use the latest AIs in your daily workflow - for... everything?"),
+			want: []EventData{
+				NewWantedCalendarEvent(
+					"66adcfc4-6827-45a2-a5b4-655923d5dd62",
+					"How to use the latest AIs in your daily workflow - for... everything?",
+					time.Date(2023, 3, 2, 18, 30, 0, 0, time.Local),
+					time.Date(2023, 3, 2, 20, 30, 0, 0, time.Local),
+				),
 			},
 		},
 		{
@@ -83,8 +78,13 @@ func TestCalendar_GetEventsOn(t *testing.T) {
 				date: time.Date(2023, 3, 21, 0, 0, 0, 0, time.Local),
 			},
 			wantErr: false,
-			want: []ical.Event{
-				NewWantedCalendarEventWithUIDAndSummary("5fb7f276-54d6-4c30-a993-92cfe962e41b", "Gespräch unter Bäumen (mit Elisa Filevich)"),
+			want: []EventData{
+				NewWantedCalendarEvent(
+					"5fb7f276-54d6-4c30-a993-92cfe962e41b",
+					"Gespräch unter Bäumen (mit Elisa Filevich)",
+					time.Date(2023, 3, 21, 19, 0, 0, 0, time.Local),
+					time.Date(2023, 3, 21, 20, 0, 0, 0, time.Local),
+				),
 			},
 		},
 		{
@@ -94,8 +94,13 @@ func TestCalendar_GetEventsOn(t *testing.T) {
 				date: time.Date(2023, 2, 24, 0, 0, 0, 0, time.Local),
 			},
 			wantErr: false,
-			want: []ical.Event{
-				NewWantedCalendarEventWithUIDAndSummary("1ec26b84-60e1-437d-a455-db6404dff879", "Drones' night"),
+			want: []EventData{
+				NewWantedCalendarEvent(
+					"1ec26b84-60e1-437d-a455-db6404dff879",
+					"Drones' night",
+					time.Date(2023, 2, 24, 18, 0, 0, 0, time.Local),
+					time.Date(2023, 2, 24, 21, 0, 0, 0, time.Local),
+				),
 			},
 		},
 		{
@@ -105,8 +110,13 @@ func TestCalendar_GetEventsOn(t *testing.T) {
 				date: time.Date(2023, 2, 27, 0, 0, 0, 0, time.Local),
 			},
 			wantErr: false,
-			want: []ical.Event{
-				NewWantedCalendarEventWithUIDAndSummary("c9158eec-083a-4798-9860-99c4a83cce0f", "offener Montag"),
+			want: []EventData{
+				NewWantedCalendarEvent(
+					"c9158eec-083a-4798-9860-99c4a83cce0f",
+					"offener Montag",
+					time.Date(2023, 2, 27, 18, 0, 0, 0, time.Local),
+					time.Date(2023, 2, 27, 22, 0, 0, 0, time.Local),
+				),
 			},
 		},
 		{
@@ -116,9 +126,19 @@ func TestCalendar_GetEventsOn(t *testing.T) {
 				date: time.Date(2023, 2, 8, 0, 0, 0, 0, time.Local),
 			},
 			wantErr: false,
-			want: []ical.Event{
-				NewWantedCalendarEventWithUIDAndSummary("3591c731-0e27-4902-9ae0-8748d46841f3", "XMPP-Meetup"),
-				NewWantedCalendarEventWithUIDAndSummary("1695d4c9-aa37-4b52-bda9-2132ac92e3a2", "xHain Wednesday meeting"),
+			want: []EventData{
+				NewWantedCalendarEvent(
+					"3591c731-0e27-4902-9ae0-8748d46841f3",
+					"XMPP-Meetup",
+					time.Date(2023, 2, 8, 18, 0, 0, 0, time.Local),
+					time.Date(2023, 2, 8, 21, 0, 0, 0, time.Local),
+				),
+				NewWantedCalendarEvent(
+					"1695d4c9-aa37-4b52-bda9-2132ac92e3a2",
+					"xHain Wednesday meeting",
+					time.Date(2023, 2, 8, 20, 30, 0, 0, time.Local),
+					time.Date(2023, 2, 8, 22, 0, 0, 0, time.Local),
+				),
 			},
 		},
 		{
@@ -128,9 +148,19 @@ func TestCalendar_GetEventsOn(t *testing.T) {
 				date: time.Date(2023, 1, 22, 0, 0, 0, 0, time.Local),
 			},
 			wantErr: false,
-			want: []ical.Event{
-				NewWantedCalendarEventWithUIDAndSummary("290b69b7-aaaf-47d4-88d1-d42366e36163", "Kindernachmittag"),
-				NewWantedCalendarEventWithUIDAndSummary("77b564a3-4e8c-4e3b-b9db-990e622d04ff", "xHain @ Camp23 Brainstorming"),
+			want: []EventData{
+				NewWantedCalendarEvent(
+					"290b69b7-aaaf-47d4-88d1-d42366e36163",
+					"Kindernachmittag",
+					time.Date(2023, 1, 22, 13, 0, 0, 0, time.Local),
+					time.Date(2023, 1, 22, 18, 0, 0, 0, time.Local),
+				),
+				NewWantedCalendarEvent(
+					"77b564a3-4e8c-4e3b-b9db-990e622d04ff",
+					"xHain @ Camp23 Brainstorming",
+					time.Date(2023, 1, 22, 20, 0, 0, 0, time.Local),
+					time.Date(2023, 1, 22, 21, 0, 0, 0, time.Local),
+				),
 			},
 		},
 	}
@@ -158,10 +188,14 @@ func TestCalendar_GetEventsOn(t *testing.T) {
 				t.Fatalf("Calendar.GetEventsOn() not the right amount of events: got = %v, want %v", got, tt.want)
 			}
 			for i := range got {
-				gotUID := got[i].Props.Get(ical.PropUID).Value
-				wantUID := tt.want[i].Props.Get(ical.PropUID).Value
-				if gotUID != wantUID {
-					t.Errorf("Calendar.GetEventsOn() got = %v, want %v", gotUID, wantUID)
+				if got[i].UID != tt.want[i].UID {
+					t.Errorf("Calendar.GetEventsOn() got UID = %v, want UID %v", got[i].UID, tt.want[i].UID)
+				}
+				if !got[i].Start.Equal(tt.want[i].Start) {
+					t.Errorf("Calendar.GetEventsOn() got Start = %v, want Start %v", got[i].Start, tt.want[i].Start)
+				}
+				if !got[i].End.Equal(tt.want[i].End) {
+					t.Errorf("Calendar.GetEventsOn() got End = %v, want End %v", got[i].End, tt.want[i].End)
 				}
 			}
 		})


### PR DESCRIPTION
For recurring events, the date given back from iCal is the date of the first entry, but not of the day that has been requested by calling `GetEventsOn()`.

Proposal: to introduce and return an object of type `EventData` with start and end date adjusted to the date of the request.

Please test before merging!!! I haven't set up the calendar-bot properly, so no proper testing has happened with this code.